### PR TITLE
UHM-8322: PIH EMR doesn't start when running OpenMRS Core 2.6.11

### DIFF
--- a/api/src/main/java/org/openmrs/module/pacsintegration/outgoing/OrderEventListener.java
+++ b/api/src/main/java/org/openmrs/module/pacsintegration/outgoing/OrderEventListener.java
@@ -16,6 +16,7 @@ package org.openmrs.module.pacsintegration.outgoing;
 
 import org.openmrs.OpenmrsObject;
 import org.openmrs.Order;
+import org.openmrs.annotation.Handler;
 import org.openmrs.api.OrderService;
 import org.openmrs.event.Event;
 import org.openmrs.event.SubscribableEventListener;
@@ -28,6 +29,7 @@ import javax.jms.Message;
 import java.util.Arrays;
 import java.util.List;
 
+@Handler
 public class OrderEventListener implements SubscribableEventListener {
 
     private OrderService orderService;

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -48,12 +48,6 @@
         </property>
     </bean>
 
-    <bean class="org.openmrs.event.Event">
-        <property name="subscription">
-            <ref bean="orderEventListener" />
-        </property>
-    </bean>
-
     <bean id="ormO01Handler" class="org.openmrs.module.pacsintegration.incoming.ORM_O01Handler">
         <property name="adminService">
             <ref bean="adminService"/>

--- a/api/src/test/java/org/openmrs/module/pacsintegration/outgoing/OrderToPacsComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/pacsintegration/outgoing/OrderToPacsComponentTest.java
@@ -82,6 +82,8 @@ public class OrderToPacsComponentTest extends BaseModuleContextSensitiveTest {
         pacsIntegrationService = mock(PacsIntegrationService.class);
         orderEventListener.setPacsIntegrationService(pacsIntegrationService);
         orderEventListener.setTaskRunner(testTaskRunner);
+        Event event = new Event();
+        event.setSubscription(orderEventListener);
 
         executeDataSet(XML_METADATA_DATASET);
         executeDataSet(XML_MAPPINGS_DATASET);


### PR DESCRIPTION
change OrderEVentListener to be wired in via a Handler